### PR TITLE
Derive version number from Git tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,23 +10,9 @@ def load_readme():
         return f.read()
 
 
-def load_about():
-    about = {}
-    with io.open(
-        os.path.join(HERE, "tutor_webhook_receiver", "__about__.py"),
-        "rt",
-        encoding="utf-8",
-    ) as f:
-        exec(f.read(), about)  # pylint: disable=exec-used
-    return about
-
-
-ABOUT = load_about()
-
-
 setup(
     name="tutor-contrib-webhook-receiver",
-    version=ABOUT["__version__"],
+    use_scm_version=True,
     url="https://github.com/hastexo/tutor-contrib-webhook-receiver",
     project_urls={
         "Code": "https://github.com/hastexo/tutor-contrib-webhook-receiver",

--- a/tutor_webhook_receiver/__about__.py
+++ b/tutor_webhook_receiver/__about__.py
@@ -1,1 +1,9 @@
-__version__ = "0.1.0"
+import pkg_resources
+# __version__ attribute as suggested by (deferred) PEP 396:
+# https://www.python.org/dev/peps/pep-0396/
+#
+# Single-source package definition as suggested (among several
+# options) by:
+# https://packaging.python.org/guides/single-sourcing-package-version/
+__version__ = pkg_resources.get_distribution(
+    'tutor-contrib-webhook-receiver').version


### PR DESCRIPTION
Rather than hard-coding the version number in __about__.py, derive the
version number from a Git tag with setuptools-scm (and then set the
version number in __about__.py from that).