### PR TITLE
build: Use Gitlint to enforce commit message style

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,6 +2,7 @@
 commit = True
 tag = True
 sign_tags = True
+message = build: Version {new_version}
 current_version = 0.0.0
 
 [bumpversion:file:CHANGELOG.md]

--- a/.githooks/post-commit
+++ b/.githooks/post-commit
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec tox -e gitlint

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,29 @@
+[general]
+contrib=contrib-title-conventional-commits
+
+# When invoked as just "gitlint" without any other arguments, Gitlint
+# processes the most recent commit message *unless* it's being fed
+# data on stdin, in which case it assumes that what comes in is a
+# commit message. That means it breaks on the pre-push hook, which
+# puts the list of to-be-pushed revisions on stdin. We can work around
+# that by telling Gitlint to always ignore stdin.
+ignore-stdin=true
+
+[ignore-body-lines]
+# Ignore certain lines in a commit body that match a regex.
+#
+# Allow long links in a list of references, as long as they are on
+# their own line.
+regex=^https?://
+
+[ignore-by-title]
+# Match commit titles matching a bumpversion commit.
+# For those commits, allow an empty message body.
+regex=^build: Version
+ignore=body-is-missing
+
+[contrib-title-conventional-commits]
+# Specify allowed commit types.
+#
+# Reference: https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0051-bp-conventional-commits.html#type
+types = build,chore,docs,feat,fix,perf,refactor,revert,style,test,temp

--- a/HACKING.md
+++ b/HACKING.md
@@ -4,6 +4,19 @@ Developer notes
 This document is for people who maintain and contribute to this
 repository.
 
+Commit messages
+---------------
+
+Commit messages follow the [Conventional
+Commits](https://www.conventionalcommits.org/) format that is also
+used by Tutor and Open edX. See
+[OEP-0051](https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0051-bp-conventional-commits.html)
+for details.
+
+We enforce the prescribed [type
+prefixes](https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0051-bp-conventional-commits.html#type)
+to be used in commit messages via
+[Gitlint](https://jorisroovers.com/gitlint/).
 
 How to run tests
 ----------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py{38,39},flake8
+envlist = gitlint,py{38,39},flake8
 
 [gh-actions]
 python =
-    3.8: py38,flake8
-    3.9: py39,flake8
+    3.8: gitlint,py38,flake8
+    3.9: gitlint,py39,flake8
 
 [flake8]
 ignore = E124,W504
@@ -23,6 +23,11 @@ commands =
 skip_install = True
 deps = flake8
 commands = flake8
+
+[testenv:gitlint]
+skip_install = True
+deps = gitlint
+commands = gitlint {posargs}
 
 [testenv:bumpversion]
 skip_install = True


### PR DESCRIPTION
Both Tutor and Open edX enforce the Conventional Commits message
format as outlined in OEP-0051. Enforce that standard here as well:

* Implement commit message testing with Gitlint.
* Use the Gitlint contrib-title-conventional-commits rule
  configuration option to enforce the commit message prefixes that
  OEP-0051 defines.
* Add gitlint integration to tox.
* Add a post-commit hook that validates the most recent commit message
  with Gitlint. That way, a commit with a non-compliant commit message
  will succeed, but the user sees a warning from the failed gitlint
  run (and then has the chance to amend the commit). The reason we do
  it this way and not via Gitlint's commit-msg hook is that the latter
  requires an interactive terminal, which tox doesn't provide.
* Add a tox test that runs Gitlint on push, and from the GitHub
  Actions workflow.
* Update the bumpversion message to comply with the required commit
  message format (using the "build" prefix).

References:
https://open-edx-proposals.readthedocs.io/en/latest/best-practices/oep-0051-bp-conventional-commits.html
https://www.conventionalcommits.org/