### PR TITLE
fix: Move DOCKER_REGISTRY reference inside the DOCKER_IMAGE default

### DIFF
--- a/tutor_webhook_receiver/patches/k8s-deployments
+++ b/tutor_webhook_receiver/patches/k8s-deployments
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: webhook_receiver
-          image: {{ DOCKER_REGISTRY }}{{ WEBHOOK_RECEIVER_DOCKER_IMAGE }}
+          image: {{ WEBHOOK_RECEIVER_DOCKER_IMAGE }}
           ports:
             - containerPort: 8090
           env:

--- a/tutor_webhook_receiver/plugin.py
+++ b/tutor_webhook_receiver/plugin.py
@@ -14,7 +14,7 @@ config = {
         "EDX_OAUTH2_SECRET": "{{ 32|random_string }}",
     },
     "defaults": {
-        "DOCKER_IMAGE": "webhook_receiver/webhook_receiver:latest",
+        "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}webhook_receiver/webhook_receiver:latest",  # noqa: E501
         "HOST": "webhooks.{{ LMS_HOST }}",
         "DB_NAME": "webhook_receiver",
         "DB_USER": "webhook_receiver01",


### PR DESCRIPTION
The purpose of being able to override `WEBHOOK_RECEIVER_DOCKER_IMAGE` includes the ability to fetch this image from a different registry than the one we use for the openedx image and others.

Tutor sets `DOCKER_REGISTRY` to `docker.io/` by default, which means that when we would set `WEBHOOK_RECEIVER_DOCKER_IMAGE` to something like `my.registry.com/webhook_receiver`, we would end up with an image reference like `docker.io/my.registry.com/webhook_receiver`, which cannot work.

Thus, include `DOCKER_REGISTRY` in the *default* for `WEBHOOK_RECEIVER_DOCKER_IMAGE` instead, so that
`WEBHOOK_RECEIVER_DOCKER_IMAGE` can be overridden with an image name that includes a non-default registry.