### PR TITLE
fix: Replace underscores in service and app names with hyphens

### DIFF
--- a/tutor_webhook_receiver/patches/caddyfile
+++ b/tutor_webhook_receiver/patches/caddyfile
@@ -1,4 +1,4 @@
 # Webhook-receiver
 {{ WEBHOOK_RECEIVER_HOST }}{$default_site_port} {
-    import proxy "webhook_receiver:8090"
+    import proxy "webhook-receiver:8090"
 }

--- a/tutor_webhook_receiver/patches/k8s-deployments
+++ b/tutor_webhook_receiver/patches/k8s-deployments
@@ -2,19 +2,19 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: webhook_receiver
+  name: webhook-receiver
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: webhook_receiver
+      app: webhook-receiver
   template:
     metadata:
       labels:
-        app: webhook_receiver
+        app: webhook-receiver
     spec:
       containers:
-        - name: webhook_receiver
+        - name: webhook-receiver
           image: {{ WEBHOOK_RECEIVER_DOCKER_IMAGE }}
           ports:
             - containerPort: 8090

--- a/tutor_webhook_receiver/patches/k8s-jobs
+++ b/tutor_webhook_receiver/patches/k8s-jobs
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: webhook_receiver-job
+  name: webhook-receiver-job
   labels:
     app.kubernetes.io/component: job
 spec:
@@ -10,7 +10,7 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-        - name: webhook_receiver
+        - name: webhook-receiver
           image: {{ WEBHOOK_RECEIVER_DOCKER_IMAGE }}
           env:
             - name: DB_MIGRATION_ENGINE

--- a/tutor_webhook_receiver/patches/k8s-services
+++ b/tutor_webhook_receiver/patches/k8s-services
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: webhook_receiver
+  name: webhook-receiver
 spec:
   type: ClusterIP
   ports:
     - port: 8090
       protocol: TCP
   selector:
-    app: webhook_receiver
+    app: webhook-receiver

--- a/tutor_webhook_receiver/patches/local-docker-compose-jobs-services
+++ b/tutor_webhook_receiver/patches/local-docker-compose-jobs-services
@@ -1,4 +1,4 @@
-webhook_receiver-job:
+webhook-receiver-job:
   image: {{ WEBHOOK_RECEIVER_DOCKER_IMAGE }}
   environment:
       - DB_MIGRATION_ENGINE=django.db.backends.mysql

--- a/tutor_webhook_receiver/patches/local-docker-compose-services
+++ b/tutor_webhook_receiver/patches/local-docker-compose-services
@@ -1,5 +1,5 @@
 ############# Webhook-receiver
-webhook_receiver:
+webhook-receiver:
   image: {{ WEBHOOK_RECEIVER_DOCKER_IMAGE }}
   command: gunicorn --env DJANGO_SETTINGS_MODULE=webhook_receiver.settings.production webhook_receiver.wsgi:application --bind 0.0.0.0:8090
   ports:

--- a/tutor_webhook_receiver/plugin.py
+++ b/tutor_webhook_receiver/plugin.py
@@ -14,7 +14,7 @@ config = {
         "EDX_OAUTH2_SECRET": "{{ 32|random_string }}",
     },
     "defaults": {
-        "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}webhook_receiver/webhook_receiver:latest",  # noqa: E501
+        "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}webhook-receiver/webhook-receiver:latest",  # noqa: E501
         "HOST": "webhooks.{{ LMS_HOST }}",
         "DB_NAME": "webhook_receiver",
         "DB_USER": "webhook_receiver01",
@@ -32,10 +32,10 @@ config = {
 
 hooks = {
     "build-image": {
-        "webhook_receiver": "{{ WEBHOOK_RECEIVER_DOCKER_IMAGE }}",
+        "webhook-receiver": "{{ WEBHOOK_RECEIVER_DOCKER_IMAGE }}",
     },
     "remote-image": {
-        "webhook_receiver": "{{ WEBHOOK_RECEIVER_DOCKER_IMAGE }}",
+        "webhook-receiver": "{{ WEBHOOK_RECEIVER_DOCKER_IMAGE }}",
     },
     "init": ["mysql", "lms", "webhook_receiver"]
 }


### PR DESCRIPTION
RFCs 1035/1123 require that DNS names do not contain underscores,
although they can contain hyphens instead. docker-compose does not
enforce this rule, but Kubernetes does.
    
Fix the service and app names for Kubernetes, and for symmetry fix
them for docker-compose as well.
    
Reference:
https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
