### PR TITLE
fix: Single-quote all env values in k8s-deployments patch

### DIFF
--- a/tutor_webhook_receiver/patches/k8s-deployments
+++ b/tutor_webhook_receiver/patches/k8s-deployments
@@ -20,34 +20,34 @@ spec:
             - containerPort: 8090
           env:
             - name: DB_MIGRATION_ENGINE
-              value: django.db.backends.mysql
+              value: 'django.db.backends.mysql'
             - name: DB_MIGRATION_NAME
-              value: {{ WEBHOOK_RECEIVER_DB_NAME }}
+              value: '{{ WEBHOOK_RECEIVER_DB_NAME }}'
             - name: DB_MIGRATION_USER
-              value: {{ WEBHOOK_RECEIVER_DB_USER }}
+              value: '{{ WEBHOOK_RECEIVER_DB_USER }}'
             - name: DB_MIGRATION_PASS
-              value: {{ WEBHOOK_RECEIVER_DB_PASSWORD }}
+              value: '{{ WEBHOOK_RECEIVER_DB_PASSWORD }}'
             - name: DB_MIGRATION_HOST
-              value: {{ MYSQL_HOST }}
+              value: '{{ MYSQL_HOST }}'
             - name: DB_MIGRATION_PORT
-              value: {{ MYSQL_PORT }}
+              value: '{{ MYSQL_PORT }}'
             - name: DB_MIGRATION_OPTIONS
               value: '{{ WEBHOOK_RECEIVER_DB_MIGRATION_OPTIONS|tojson }}'
             - name: DJANGO_SECRET_KEY
-              value: {{ WEBHOOK_RECEIVER_DJANGO_SECRET_KEY }}
+              value: '{{ WEBHOOK_RECEIVER_DJANGO_SECRET_KEY }}'
             - name: DJANGO_WEBHOOK_RECEIVER_LMS_BASE_URL
-              value: {{ WEBHOOK_RECEIVER_LMS_ROOT_URL }}
+              value: '{{ WEBHOOK_RECEIVER_LMS_ROOT_URL }}'
             - name: DJANGO_WEBHOOK_RECEIVER_EDX_OAUTH2_KEY
-              value: {{ WEBHOOK_RECEIVER_EDX_OAUTH2_KEY }}
+              value: '{{ WEBHOOK_RECEIVER_EDX_OAUTH2_KEY }}'
             - name: DJANGO_WEBHOOK_RECEIVER_EDX_OAUTH2_SECRET
-              value: {{ WEBHOOK_RECEIVER_EDX_OAUTH2_SECRET }}
+              value: '{{ WEBHOOK_RECEIVER_EDX_OAUTH2_SECRET }}'
             - name: DJANGO_WEBHOOK_RECEIVER_SETTINGS_SHOPIFY_SHOP_DOMAIN
-              value: "{{ WEBHOOK_RECEIVER_SHOPIFY_SHOP_DOMAIN }}"
+              value: '{{ WEBHOOK_RECEIVER_SHOPIFY_SHOP_DOMAIN }}'
             - name: DJANGO_WEBHOOK_RECEIVER_SETTINGS_SHOPIFY_API_KEY
-              value: "{{ WEBHOOK_RECEIVER_SHOPIFY_API_KEY }}"
+              value: '{{ WEBHOOK_RECEIVER_SHOPIFY_API_KEY }}'
             - name: DJANGO_WEBHOOK_RECEIVER_SETTINGS_WOOCOMMERCE_SOURCE
-              value: "{{ WEBHOOK_RECEIVER_WOOCOMMERCE_SOURCE }}"
+              value: '{{ WEBHOOK_RECEIVER_WOOCOMMERCE_SOURCE }}'
             - name: DJANGO_WEBHOOK_RECEIVER_SETTINGS_WOOCOMMERCE_SECRET
-              value: "{{ WEBHOOK_RECEIVER_WOOCOMMERCE_SECRET }}"
+              value: '{{ WEBHOOK_RECEIVER_WOOCOMMERCE_SECRET }}'
             - name: DJANGO_LOG_LEVEL
-              value: {{ WEBHOOK_RECEIVER_DJANGO_LOG_LEVEL }}
+              value: '{{ WEBHOOK_RECEIVER_DJANGO_LOG_LEVEL }}'


### PR DESCRIPTION
Kubernetes wants all values passed in via the env dictionary to be
strings.
    
However, since MYSQL_PORT is an integer value, Kubernetes' YAML parser
reads it as such if unquoted, and stubbornly refuses to cast it to a
string.
    
Thus, quote that value, and so as not to run into similar issues in
the future, quote all env values in the k8s-deployments.

This is based on #10, but can land independently of it.