### PR TITLE
fix: Move the gunicorn command to Dockerfile

### DIFF
--- a/tutorwebhookreceiver/patches/local-docker-compose-services
+++ b/tutorwebhookreceiver/patches/local-docker-compose-services
@@ -1,7 +1,6 @@
 ############# webhookreceiver
 webhookreceiver:
   image: {{ WEBHOOKRECEIVER_DOCKER_IMAGE }}
-  command: gunicorn --env DJANGO_SETTINGS_MODULE=webhook_receiver.settings.production webhook_receiver.wsgi:application --bind 0.0.0.0:8090
   ports:
       - "8090:8090"
   restart: unless-stopped

--- a/tutorwebhookreceiver/templates/webhookreceiver/build/webhookreceiver/Dockerfile
+++ b/tutorwebhookreceiver/templates/webhookreceiver/build/webhookreceiver/Dockerfile
@@ -8,3 +8,6 @@ RUN apt-get update && \
 WORKDIR ./webhooks
 RUN pip install --upgrade pip && \
     pip install -r requirements/production.txt --exists-action w
+EXPOSE 8090
+CMD ["gunicorn", "--env", "DJANGO_SETTINGS_MODULE=webhook_receiver.settings.production",
+    "webhook_receiver.wsgi:application", "--bind", "0.0.0.0:8090"]


### PR DESCRIPTION
Kubernetes deployments didn't have a command to start up the gunicorn
server, so the webhookreceiver pod crashes on start up.
We move the gunicorn command to the Dockerfile to provide an
entrypoint for both docker-compose services and kubernetes deployments.