### PR TITLE
fix: Change the entrypoint CMD style

### DIFF
--- a/tutorwebhookreceiver/templates/webhookreceiver/build/webhookreceiver/Dockerfile
+++ b/tutorwebhookreceiver/templates/webhookreceiver/build/webhookreceiver/Dockerfile
@@ -9,5 +9,4 @@ WORKDIR ./webhooks
 RUN pip install --upgrade pip && \
     pip install -r requirements/production.txt --exists-action w
 EXPOSE 8090
-CMD ["gunicorn", "--env", "DJANGO_SETTINGS_MODULE=webhook_receiver.settings.production",
-    "webhook_receiver.wsgi:application", "--bind", "0.0.0.0:8090"]
+CMD gunicorn --env DJANGO_SETTINGS_MODULE=webhook_receiver.settings.production webhook_receiver.wsgi:application --bind 0.0.0.0:8090


### PR DESCRIPTION
The previous CMD style breaks in Kubernetes deployments.