### PR TITLE
fix: Don't grant webhook_receiver_app_user superuser privileges

### DIFF
--- a/tutorwebhookreceiver/templates/webhookreceiver/hooks/lms/init
+++ b/tutorwebhookreceiver/templates/webhookreceiver/hooks/lms/init
@@ -1,5 +1,5 @@
 # create a user for webhook-receiver application
-./manage.py lms manage_user webhook_receiver_app_user webhook_receiver_app_user@openedx --staff --superuser --unusable-password
+./manage.py lms manage_user webhook_receiver_app_user webhook_receiver_app_user@openedx --staff --unusable-password
 
 # create OAuth2 client
 ./manage.py lms create_dot_application \


### PR DESCRIPTION
As documented in the webhook-receiver README, the webook receiver app user (which the webhook receiver uses to make REST API calls to the LMS) needs Staff privileges in order to be able to enroll users in all courses — otherwise it would need to be added to all courses individually as course staff, which isn't practical.

However, there is absolutely no need for superuser privileges. Remove them from the LMS init hook.

Reference:
https://github.com/hastexo/webhook-receiver/#edx-oauth2-client