### PR TITLE
build: Add setuptools-scm to setup_requires list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+* Fix version number as it appears in pip list (previously, all
+  installations would show up as version 0.0.0, including
+  installations from the 0.0.1 tag).
+
+
 ## Version 0.0.1 (2022-02-25)
 
 **Experimental. Do not use in production.**

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.8",
     install_requires=["tutor"],
+    setup_requires=["setuptools-scm"],
     entry_points={
         "tutor.plugin.v0": [
             "webhookreceiver = tutorwebhookreceiver.plugin"


### PR DESCRIPTION
If we don't include `setuptools-scm` in the `setup_requires` list in `setup.py`, then the package will not read its version information from its Git tag, rendering the whole `setuptools-scm` approach moot.

Thus, include it in that list.