### PR TITLE
feat: Add support for Tutor 17 / Open edX Quince

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Support Tutor 17 and Open edX Quince.
+
 ## Version 2.1.1 (2023-09-08)
 
 * [fix] In the init job, ensure compatibility with MySQL 8.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ appropriate one:
 | Nutmeg           | `>=14.0, <15`     | `nutmeg`      | 1.x.x          |
 | Olive            | `>=15.0, <16`     | `main`        | 2.x.x          |  
 | Palm             | `>=16.0, <17`     | `main`        | 2.x.x          |
+| Quince           | `>=17.0, <18`     | `main`        | 2.x.x          |
 
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <17, >=15.0.0"],
+    install_requires=["tutor <18, >=15.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={
         "tutor.plugin.v1": [


### PR DESCRIPTION
* Update the install_requires list to support Tutor 17.
* Update the compatibility matrix in the README accordingly.