### PR TITLE
feat: Make location and revision of webhook-receiver repo configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Make the location and revision of the webhook-receiver application repository configurable.
+
 ## Version 2.3.0 (2024-02-07)
 
 * [Enhancement] Add a new configuration variable, `WEBHOOKRECEIVER_WOOCOMMERCE_REQUIRE_PAYMENT`, for requiring completed payment on WooCommerce orders.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Configuration
 * `WEBHOOKRECEIVER_DB_MIGRATION_OPTIONS` (default `{}`)
 * `WEBHOOKRECEIVER_DJANGO_LOG_LEVEL` (default `"DEBUG"`)
 * `WEBHOOKRECEIVER_EDX_OAUTH2_KEY` (default `"webhook_receiver"`)
+* `WEBHOOKRECEIVER_REPOSITORY` (default `"https://github.com/hastexo/webhook-receiver.git"`)
+* `WEBHOOKRECEIVER_REVISION` (default `"main"`)
 * `WEBHOOKRECEIVER_SHOPIFY_SHOP_DOMAIN` (default `""`)
 * `WEBHOOKRECEIVER_SHOPIFY_API_KEY` (default `""`)
 * `WEBHOOKRECEIVER_WOOCOMMERCE_SOURCE` (default `""`)

--- a/tutorwebhookreceiver/plugin.py
+++ b/tutorwebhookreceiver/plugin.py
@@ -22,6 +22,8 @@ config = {
         "LMS_ROOT_URL":
             "{{ 'https' if ENABLE_HTTPS else 'http' }}://{{ LMS_HOST }}",
         "EDX_OAUTH2_KEY": "webhook_receiver",
+        "REPOSITORY": "https://github.com/hastexo/webhook-receiver.git",  # noqa: E501
+        "REVISION": "main",
         "SHOPIFY_SHOP_DOMAIN": "",
         "SHOPIFY_API_KEY": "",
         "WOOCOMMERCE_SOURCE": "",

--- a/tutorwebhookreceiver/templates/webhookreceiver/build/webhookreceiver/Dockerfile
+++ b/tutorwebhookreceiver/templates/webhookreceiver/build/webhookreceiver/Dockerfile
@@ -4,8 +4,9 @@ RUN python3 -m venv /webhook_receiver/venv/
 ENV PATH "/webhook_receiver/venv/bin:$PATH"
 RUN apt-get update && \
     apt-get install -y --no-install-recommends default-libmysqlclient-dev && \
-    git clone https://github.com/hastexo/webhook-receiver.git ./webhooks
+    git clone {{ WEBHOOKRECEIVER_REPOSITORY }} ./webhooks
 WORKDIR ./webhooks
+RUN git checkout {{ WEBHOOKRECEIVER_REVISION }}
 RUN pip install --upgrade pip && \
     pip install -r requirements/production.txt --exists-action w
 EXPOSE 8090


### PR DESCRIPTION
Add configuration settings that allow us to set the source and
checked-out revision (branch, tag, or commit) of the webhook-receiver
repository.
