### PR TITLE
docs: Update version compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ appropriate one:
 |------------------|-------------------|---------------|----------------|
 | Lilac            | `>=12.0, <13`     | Not supported | Not supported  |
 | Maple            | `>=13.2, <14`[^1] | `maple`       | 0.1.x          |
-| Nutmeg           | `>=14.0, <15`     | `nutmeg`      | 1.x.x          |
-| Olive            | `>=15.0, <16`     | `main`        | 2.x.x          |  
-| Palm             | `>=16.0, <17`     | `main`        | 2.x.x          |
-| Quince           | `>=17.0, <18`     | `main`        | 2.x.x          |
+| Nutmeg           | `>=14.0, <15`     | `nutmeg`      | 1.0.x          |
+| Olive            | `>=15.0, <16`     | `olive`       | 2.2.x          |
+| Palm             | `>=16.0, <17`     | `palm`        | 2.3.x          |
+| Quince           | `>=17.0, <18`     | `main`        | 2.4.x          |
 
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or


### PR DESCRIPTION
Explain that the 2.2.x series is for Olive, 2.3.x for Palm, and 2.4.x for Quince.
