### PR TITLE
feat: Add support for Tutor 18 / Open edX Redwood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Support Tutor 18 and Open edX Redwood.
+
 ## Version 2.5.0 (2024-04-05)
 
 * [Enhancement] Support Python 3.12.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ appropriate one:
 | Olive            | `>=15.0, <16`     | `olive`       | 2.2.x          |
 | Palm             | `>=16.0, <17`     | `palm`        | 2.3.x          |
 | Quince           | `>=17.0, <18`     | `main`        | >=2.4.0        |
+| Redwood          | `>=18.0, <19`     | `main`        | >=2.4.0        |
 
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor <18, >=15.0.0"],
+    install_requires=["tutor <19, >=15.0.0"],
     setup_requires=["setuptools-scm"],
     entry_points={
         "tutor.plugin.v1": [


### PR DESCRIPTION
* Update the install_requires list to support Tutor 18.
* Update the compatibility matrix in the README accordingly.