### PR TITLE
chore: Drop support for Python 3.8

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.8
           - 3.9
           - "3.10"
           - 3.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* [Chore] Drop Python 3.8 support.
+
+When updating your plugin to this version, you'll need to rebuild the image.
+
 ## Version 2.6.0 (2024-08-01)
 
 * [Enhancement] Support Tutor 18 and Open edX Redwood.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ appropriate one:
 | Nutmeg           | `>=14.0, <15`     | `nutmeg`      | 1.0.x          |
 | Olive            | `>=15.0, <16`     | `olive`       | 2.2.x          |
 | Palm             | `>=16.0, <17`     | `palm`        | 2.3.x          |
-| Quince           | `>=17.0, <18`     | `main`        | >=2.4.0        |
-| Redwood          | `>=18.0, <19`     | `main`        | >=2.4.0        |
+| Quince           | `>=17.0, <18`     | `quince`      | `>=2.4.0, <3`  |
+| Redwood          | `>=18.0, <19`     | `main`        | `>=3`          |
 
 
 [^1]: For Open edX Maple and Tutor 13, you must run version 13.2.0 or

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         "License :: OSI Approved :: GNU Affero General Public License v3",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = gitlint,py{38,39,310,311,312},flake8
+envlist = gitlint,py{39,310,311,312},flake8
 
 [gh-actions]
 python =
-    3.8: gitlint,py38,flake8
     3.9: gitlint,py39,flake8
     3.10: gitlint,py310,flake8
     3.11: gitlint,py311,flake8

--- a/tutorwebhookreceiver/templates/webhookreceiver/build/webhookreceiver/Dockerfile
+++ b/tutorwebhookreceiver/templates/webhookreceiver/build/webhookreceiver/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.11
 ENV PYTHONUNBUFFERED 1
 RUN python3 -m venv /webhook_receiver/venv/
 ENV PATH "/webhook_receiver/venv/bin:$PATH"


### PR DESCRIPTION
Python 3.8 will end security support on 2024-10-31; drop support for Python 3.8 in this plugin.