### PR TITLE
feat: Allow to override the base image for builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* [Enhancement] Allow to override the Dockerfile base image.
+
 ## Version 3.1.0 (2025-01-03)
 
 * [Enhancement] Support Tutor 19 and Open edX Sumac.

--- a/tutorwebhookreceiver/plugin.py
+++ b/tutorwebhookreceiver/plugin.py
@@ -16,6 +16,7 @@ config = {
     },
     "defaults": {
         "VERSION": __version__,
+        "BASE_IMAGE": "docker.io/python:3.11",
         "DOCKER_IMAGE": "{{ DOCKER_REGISTRY }}webhookreceiver:{{ WEBHOOKRECEIVER_VERSION }}",  # noqa: E501
         "HOST": "webhooks.{{ LMS_HOST }}",
         "DB_NAME": "webhook_receiver",

--- a/tutorwebhookreceiver/templates/webhookreceiver/build/webhookreceiver/Dockerfile
+++ b/tutorwebhookreceiver/templates/webhookreceiver/build/webhookreceiver/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11
+FROM {{ WEBHOOKRECEIVER_BASE_IMAGE }}
 ENV PYTHONUNBUFFERED 1
 RUN python3 -m venv /webhook_receiver/venv/
 ENV PATH "/webhook_receiver/venv/bin:$PATH"


### PR DESCRIPTION
Add a config option `WEBHOOKRECEIVER_BASE_IMAGE` that allows to override the base image for builds.